### PR TITLE
Add ToString() to NiStringRef

### DIFF
--- a/NiflySharp/BaseTypes/NiStringRef.cs
+++ b/NiflySharp/BaseTypes/NiStringRef.cs
@@ -1,4 +1,4 @@
-﻿using NiflySharp.Stream;
+using NiflySharp.Stream;
 using System.Text;
 
 namespace NiflySharp
@@ -71,6 +71,10 @@ namespace NiflySharp
         public override int GetHashCode()
         {
             return _str.GetHashCode();
+        }
+
+        public override string ToString() {
+            return _str;
         }
     }
 }


### PR DESCRIPTION
When debugging in Visual Studio, the value was shown as the default one and I have to expand it to see what is the string. So I added ToString() override to make our life easier. 