### PR TITLE
Dispose FileStream in Load(string) to avoid handle leak

### DIFF
--- a/NiflySharp/NifFile.cs
+++ b/NiflySharp/NifFile.cs
@@ -152,7 +152,11 @@ namespace NiflySharp
                 return 1;
             }
 
-            return Load(file, options);
+            // C# has no RAII: wrap in `using` so the file handle is released deterministically.
+            // Matches C++ nifly NifFile.cpp:181-182 where `std::ifstream file(fileName, ...)` is a
+            // local that destructs at scope end.
+            using (file)
+                return Load(file, options);
         }
 
         /// <summary>

--- a/NiflySharp/NifFile.cs
+++ b/NiflySharp/NifFile.cs
@@ -142,21 +142,15 @@ namespace NiflySharp
         /// </returns>
         public int Load(string fileName, NifFileLoadOptions options = null)
         {
-            FileStream file;
             try
             {
-                file = new FileStream(fileName, FileMode.Open, FileAccess.Read);
+                using var file = new FileStream(fileName, FileMode.Open, FileAccess.Read);
+                return Load(file, options);
             }
             catch
             {
                 return 1;
             }
-
-            // C# has no RAII: wrap in `using` so the file handle is released deterministically.
-            // Matches C++ nifly NifFile.cpp:181-182 where `std::ifstream file(fileName, ...)` is a
-            // local that destructs at scope end.
-            using (file)
-                return Load(file, options);
         }
 
         /// <summary>


### PR DESCRIPTION
`Load(string fileName)` opens a `FileStream` but doesn't dispose it, leaving the file handle locked until GC. By contrast `Save(string fileName)` already closes its stream explicitly, so the asymmetry is internal.

C++ reference: `nifly/NifFile.cpp:181-182` — `std::ifstream file(...)` is a local that RAII-closes at scope end.

Fix: wrap the `FileStream` in a `using` block.

Maps to issue #15 item C9.
