### PR TITLE
Use continue instead of return in PrepareData shape loop

### DIFF
--- a/NiflySharp/NifFile.cs
+++ b/NiflySharp/NifFile.cs
@@ -406,8 +406,10 @@ namespace NiflySharp
                     {
                         if (bsDynamicTriShape.VertexDataSSE != null)
                         {
+                            // Skip this dynamic shape if counts disagree — must not abort
+                            // the enclosing foreach(shape) loop.
                             if (bsDynamicTriShape.VertexDataSSE.Count != bsDynamicTriShape.Vertices.Count)
-                                return;
+                                continue;
 
                             var vertexDataSpan = CollectionsMarshal.AsSpan(bsDynamicTriShape.VertexDataSSE);
 
@@ -422,7 +424,7 @@ namespace NiflySharp
                         else if (bsDynamicTriShape.VertexData != null)
                         {
                             if (bsDynamicTriShape.VertexData.Count != bsDynamicTriShape.Vertices.Count)
-                                return;
+                                continue;
 
                             var vertexDataSpan = CollectionsMarshal.AsSpan(bsDynamicTriShape.VertexData);
 


### PR DESCRIPTION
In `PrepareData`, the `BSDynamicTriShape` size-mismatch path uses `return`, which aborts the entire `foreach` over shapes. Any subsequent shape silently skips preparation.

C++ reference: `nifly/NifFile.cpp:1987, 1991, 1995` — equivalent per-shape early-outs use `continue`.

Fix: replace the two `return` statements with `continue`.

Maps to issue #15 item C7.
