### PR TITLE
NiBlockRefArray: fix Resize loop and keep arraySize consistent

### DIFF
--- a/NiflySharp/BaseTypes/NiBlockRefArray.cs
+++ b/NiflySharp/BaseTypes/NiBlockRefArray.cs
@@ -38,7 +38,11 @@ namespace NiflySharp
                 if (size > _refs.Capacity)
                     _refs.Capacity = size;
 
-                for (int i = 0; i < size; i++)
+                // Fill only the new slots from `cur` up to `size` — the previous
+                // `for (i=0; i<size)` appended `size` entries on every grow, producing
+                // a final count of `cur + size` instead of `size`. Matches C++ nifly
+                // BasicTypes.hpp:863 `refs.resize(arraySize)` semantics.
+                for (int i = cur; i < size; i++)
                     _refs.Add(new NiBlockRef<T>() { List = _refs });
             }
 
@@ -68,7 +72,12 @@ namespace NiflySharp
 
         public override void AddBlockRef(int id)
         {
+            // Matches C++ nifly BasicTypes.hpp:869-872: bump arraySize together with the
+            // list Add so callers reading _listSizeStream see a consistent count between
+            // Sync()s. Before, _listSizeStream stayed stale until the next Sync and any
+            // consumer that touched it directly saw the pre-Add count.
             _refs.Add(new NiBlockRef<T>(id) { List = _refs });
+            _listSizeStream = _refs.Count;
         }
 
         public override int GetBlockRef(int id)
@@ -87,8 +96,13 @@ namespace NiflySharp
 
         public override void RemoveBlockRef(int id)
         {
+            // Matches C++ nifly BasicTypes.hpp:886-890: keep arraySize in step with the
+            // list Remove.
             if (id != NiRef.NPOS && _refs.Count > id)
+            {
                 _refs.RemoveAt(id);
+                _listSizeStream = _refs.Count;
+            }
         }
 
         public override IEnumerable<int> Indices

--- a/NiflySharp/BaseTypes/NiBlockRefArray.cs
+++ b/NiflySharp/BaseTypes/NiBlockRefArray.cs
@@ -38,10 +38,7 @@ namespace NiflySharp
                 if (size > _refs.Capacity)
                     _refs.Capacity = size;
 
-                // Fill only the new slots from `cur` up to `size` — the previous
-                // `for (i=0; i<size)` appended `size` entries on every grow, producing
-                // a final count of `cur + size` instead of `size`. Matches C++ nifly
-                // BasicTypes.hpp:863 `refs.resize(arraySize)` semantics.
+                // Fill only the new slots from `cur` up to `size`
                 for (int i = cur; i < size; i++)
                     _refs.Add(new NiBlockRef<T>() { List = _refs });
             }
@@ -72,10 +69,6 @@ namespace NiflySharp
 
         public override void AddBlockRef(int id)
         {
-            // Matches C++ nifly BasicTypes.hpp:869-872: bump arraySize together with the
-            // list Add so callers reading _listSizeStream see a consistent count between
-            // Sync()s. Before, _listSizeStream stayed stale until the next Sync and any
-            // consumer that touched it directly saw the pre-Add count.
             _refs.Add(new NiBlockRef<T>(id) { List = _refs });
             _listSizeStream = _refs.Count;
         }
@@ -96,8 +89,6 @@ namespace NiflySharp
 
         public override void RemoveBlockRef(int id)
         {
-            // Matches C++ nifly BasicTypes.hpp:886-890: keep arraySize in step with the
-            // list Remove.
             if (id != NiRef.NPOS && _refs.Count > id)
             {
                 _refs.RemoveAt(id);


### PR DESCRIPTION
Three related issues in `NiBlockRefArray`:

1. **`Resize` grow loop starts at 0.** When growing from `cur > 0` to `size`, the loop `for (int i = 0; i < size; i++) Add(...)` appends `size` extra entries instead of `size - cur`, leaving the list at `cur + size`. Fix: start the loop at `cur`.
2. **`AddBlockRef` doesn't bump `_listSizeStream`.** The mirror that gets serialized stays stale until an explicit `Sync()`. Matches `nifly/include/BasicTypes.hpp:863-872` where C++ does `arraySize++` atomically inside `AddBlockRef`.
3. **`RemoveBlockRef` has the symmetric bug.** Matches `nifly/include/BasicTypes.hpp:886-890` (`arraySize--`).

Maps to issue #15 items D10 and D11.
