### PR TITLE
Sync NumChildren/NumBones mirror fields after AddBlockRef

### DIFF
--- a/NiflySharp/NifFile.cs
+++ b/NiflySharp/NifFile.cs
@@ -619,6 +619,10 @@ namespace NiflySharp
                 // Clone missing node into the right parent
                 boneID = CloneNamedNode(boneName, srcNif);
                 nodeParent.Children.AddBlockRef(boneID);
+                // Keep the NumChildren mirror in step with the list. The auto-sync in
+                // NiNode.Sync() only runs at save time; any reader that touches
+                // NumChildren between AddBlockRef and the next Sync sees stale data.
+                nodeParent.NumChildren = (uint)nodeParent.Children.Count;
             }
             else
             {
@@ -631,6 +635,7 @@ namespace NiflySharp
                             r.Clear();
 
                     nodeParent.Children.AddBlockRef(boneID);
+                    nodeParent.NumChildren = (uint)nodeParent.Children.Count;
 
                     // Set transform to parent
                     node.TransformToParent = srcNode.TransformToParent;
@@ -715,10 +720,16 @@ namespace NiflySharp
                 // Assign copied geometry to the same parent
                 var parentNode = GetParentNode(srcShape);
                 if (parentNode != null)
+                {
                     parentNode.Children.AddBlockRef(destId);
+                    parentNode.NumChildren = (uint)parentNode.Children.Count;
+                }
             }
             else if (rootNode != null)
+            {
                 rootNode.Children.AddBlockRef(destId);
+                rootNode.NumChildren = (uint)rootNode.Children.Count;
+            }
 
             // Children
             CloneChildren(destShape, srcNif);
@@ -775,6 +786,8 @@ namespace NiflySharp
                             destBoneCont.Bones.AddBlockRef(boneID);
                     }
                 }
+                // Keep NumBones mirror in step (same reasoning as NumChildren above).
+                destBoneCont.NumBones = (uint)destBoneCont.Bones.Count;
             }
 
             return destShape;


### PR DESCRIPTION
`CloneNamedNode` and `CloneShape` add refs via `parent.Children.AddBlockRef(...)` and `destBoneCont.Bones.AddBlockRef(...)` but don't update the corresponding `NumChildren` / `NumBones` mirror fields. The values stay stale until an explicit `Sync()`, and any code path that reads the mirror before Sync (e.g. immediate inspection after clone, or save without intervening sync) sees a wrong count.

Call sites updated:
- `CloneNamedNode` — `parent.Children.AddBlockRef`
- `CloneShape` — `parent.Children.AddBlockRef` (two branches)
- `CloneShape` — `destBoneCont.Bones.AddBlockRef` loop

C++ reference: `nifly/include/BasicTypes.hpp:869-872` — C++ bumps `arraySize` atomically inside `AddBlockRef` itself, keeping the mirror always in sync.

Note: this PR sits on top of the recent clone refactor (`f1f3404`); the diff applies cleanly and doesn't touch the generated clone logic.

Maps to issue #15 item C9 (clone-side, distinct from C8 PR).
