### PR TITLE
OptimizeFor: invert vertex-color All/Any check to match C++

### DIFF
--- a/NiflySharp/NifFile.cs
+++ b/NiflySharp/NifFile.cs
@@ -1862,7 +1862,6 @@ namespace NiflySharp
                     if (withoutVertexColors && geomData.HasVertexColors)
                     {
                         // Remove vertex colors only if ALL elements are white/neutral.
-                        // Matches C++ nifly NifFile.cpp:1544-1549 (remove when all == 0xFFFFFFFF).
                         var white = new Color4(1.0f, 1.0f, 1.0f, 1.0f);
                         withoutVertexColors = geomData.VertexColors.All(c => c == white);
                     }
@@ -2174,7 +2173,6 @@ namespace NiflySharp
                     if (withoutVertexColors && bsTriShape.HasVertexColors)
                     {
                         // Remove vertex colors only if ALL elements are white/neutral.
-                        // Matches C++ nifly NifFile.cpp:1544-1549 (remove when all == 0xFFFFFFFF).
                         var white = new Color4(1.0f, 1.0f, 1.0f, 1.0f);
                         withoutVertexColors = vertexColors.All(c => c == white);
                     }

--- a/NiflySharp/NifFile.cs
+++ b/NiflySharp/NifFile.cs
@@ -1861,9 +1861,10 @@ namespace NiflySharp
 
                     if (withoutVertexColors && geomData.HasVertexColors)
                     {
-                        // Remove vertex colors if all elements are white/neutral
+                        // Remove vertex colors only if ALL elements are white/neutral.
+                        // Matches C++ nifly NifFile.cpp:1544-1549 (remove when all == 0xFFFFFFFF).
                         var white = new Color4(1.0f, 1.0f, 1.0f, 1.0f);
-                        withoutVertexColors = geomData.VertexColors.Any(c => c != white);
+                        withoutVertexColors = geomData.VertexColors.All(c => c == white);
                     }
 
                     bool isHeadPartEyes = false;
@@ -2172,9 +2173,10 @@ namespace NiflySharp
 
                     if (withoutVertexColors && bsTriShape.HasVertexColors)
                     {
-                        // Remove vertex colors if all elements are white/neutral
+                        // Remove vertex colors only if ALL elements are white/neutral.
+                        // Matches C++ nifly NifFile.cpp:1544-1549 (remove when all == 0xFFFFFFFF).
                         var white = new Color4(1.0f, 1.0f, 1.0f, 1.0f);
-                        withoutVertexColors = vertexColors.Any(c => c != white);
+                        withoutVertexColors = vertexColors.All(c => c == white);
                     }
 
                     bool withoutNormals = false;


### PR DESCRIPTION
Both `OptimizeFor` toSSE and toLE compute `withoutVertexColors` as `Any(c => c != white)`, which sets the flag whenever **any** color is non-white. The intent (and the C++ behavior) is the opposite: vertex colors should be removable only when **all** colors are white/neutral.

Net effect of the bug: vertex colors get stripped from shapes that have any non-white color and preserved on shapes that are all white — exactly backwards.

C++ reference: `nifly/NifFile.cpp:1544-1552` uses `std::all_of(... == white)`.

Fix: replace `Any(c => c != white)` with `All(c => c == white)` in both toSSE and toLE.

Maps to issue #15 item A1.
