### PR TITLE
OptimizeFor toSSE: honor withoutNormals when creating bsOptShape

### DIFF
--- a/NiflySharp/NifFile.cs
+++ b/NiflySharp/NifFile.cs
@@ -1970,7 +1970,10 @@ namespace NiflySharp
                     bsOptShape.Rotation = shape.Rotation;
                     bsOptShape.Scale = shape.Scale;
 
-                    bsOptShape.Create(Header.Version, geomData.Vertices, geomData.Triangles, geomData.UVSets, geomData.Normals);
+                    // Honor the withoutNormals flag — ModelSpace shaders must drop normals.
+                    // Matches C++ nifly NifFile.cpp:1565-1569 nulling `normals` before the
+                    // equivalent Create call at NifFile.cpp:1652.
+                    bsOptShape.Create(Header.Version, geomData.Vertices, geomData.Triangles, geomData.UVSets, !withoutNormals ? geomData.Normals : null);
                     bsOptShape.Flags_ui = shape.Flags_ui;
 
                     // Restore old bounds for static meshes or when calc bounds is off

--- a/NiflySharp/NifFile.cs
+++ b/NiflySharp/NifFile.cs
@@ -1971,8 +1971,6 @@ namespace NiflySharp
                     bsOptShape.Scale = shape.Scale;
 
                     // Honor the withoutNormals flag — ModelSpace shaders must drop normals.
-                    // Matches C++ nifly NifFile.cpp:1565-1569 nulling `normals` before the
-                    // equivalent Create call at NifFile.cpp:1652.
                     bsOptShape.Create(Header.Version, geomData.Vertices, geomData.Triangles, geomData.UVSets, !withoutNormals ? geomData.Normals : null);
                     bsOptShape.Flags_ui = shape.Flags_ui;
 


### PR DESCRIPTION
The toSSE branch of `OptimizeFor` always passes `geomData.Normals` when constructing `bsOptShape`, even when `withoutNormals` is true. The toLE branch already uses the correct `!withoutNormals ? ... : null` pattern; this brings toSSE in line.

C++ reference: `nifly/NifFile.cpp:1565-1569` — C++ nulls `normals = nullptr` before passing it to `Create()` when `removeNormals` is true.

Fix: gate the `Normals` argument on `withoutNormals`.

Maps to issue #15 item A2.
