### PR TITLE
Sort bone weights descending before Resize(4) truncation

### DIFF
--- a/NiflySharp/NifFile.cs
+++ b/NiflySharp/NifFile.cs
@@ -2405,13 +2405,10 @@ namespace NiflySharp
                 boneIndex++;
             }
 
-            // Sort weights and corresponding bones
+            // Sort weights and corresponding bones.
+            // Descending (largest weights first):
+            // Weakest influences on vertices with more than 4 bones are truncated.
             foreach (var bw in vertBoneWeights)
-                // Sort descending: largest weights first. The subsequent Resize(4) below
-                // truncates the tail, so ascending-order would discard the STRONGEST
-                // influences on vertices with more than 4 bones — catastrophic for
-                // skinning of dense rigs. Matches C++ nifly NifFile.hpp:50
-                // `BoneWeightsSort` operator returning `rhs.weight < lhs.weight`.
                 bw.Value.Sort((lhs, rhs) => rhs.Weight.CompareTo(lhs.Weight));
 
             // Enforce maximum vertex bone weight count

--- a/NiflySharp/NifFile.cs
+++ b/NiflySharp/NifFile.cs
@@ -2407,7 +2407,12 @@ namespace NiflySharp
 
             // Sort weights and corresponding bones
             foreach (var bw in vertBoneWeights)
-                bw.Value.Sort((lhs, rhs) => lhs.Weight.CompareTo(rhs.Weight));
+                // Sort descending: largest weights first. The subsequent Resize(4) below
+                // truncates the tail, so ascending-order would discard the STRONGEST
+                // influences on vertices with more than 4 bones — catastrophic for
+                // skinning of dense rigs. Matches C++ nifly NifFile.hpp:50
+                // `BoneWeightsSort` operator returning `rhs.weight < lhs.weight`.
+                bw.Value.Sort((lhs, rhs) => rhs.Weight.CompareTo(lhs.Weight));
 
             // Enforce maximum vertex bone weight count
             const ushort maxBonesPerVertex = 4;


### PR DESCRIPTION
`UpdateSkinPartitions` sorts per-vertex bone weights with `lhs.CompareTo(rhs)` (ascending) and then calls `Resize(4)`, which discards the **heaviest** weights instead of the lightest. Vertices with more than 4 influences end up keeping their weakest bones.

C++ reference: `nifly/include/NifFile.hpp:50` — `BoneWeightsSort::operator()` returns `rhs.weight < lhs.weight`, i.e. descending.

Fix: change the comparator to `rhs.CompareTo(lhs)`.

Maps to issue #15 item B5.
