### PR TITLE
SkinPartition: compare Bones lists by content, not reference

### DIFF
--- a/NiflySharp/NifFile.cs
+++ b/NiflySharp/NifFile.cs
@@ -2599,7 +2599,13 @@ namespace NiflySharp
                 if (i != 0)
                 {
                     // Start a new set if the previous bones are different
-                    if (skinPart.Partitions.Count > i && skinPart.Partitions[i].Bones != skinPart.Partitions[i - 1].Bones)
+                    // Compare bone palettes by content (SequenceEqual), not by List<> reference.
+                    // Matches C++ nifly NifFile.cpp:4458 `partitions[i].bones != partitions[i - 1].bones`
+                    // where `bones` is `std::vector<uint16_t>` whose `operator!=` is a content
+                    // comparison. The C# `List<ushort>` `!=` falls back to reference equality and
+                    // is almost always true, forcing PF_START_NET_BONESET on every partition.
+                    if (skinPart.Partitions.Count > i &&
+                        !skinPart.Partitions[i].Bones.SequenceEqual(skinPart.Partitions[i - 1].Bones))
                         flags |= BSPartFlag.PF_START_NET_BONESET;
                 }
                 else

--- a/NiflySharp/NifFile.cs
+++ b/NiflySharp/NifFile.cs
@@ -2600,10 +2600,6 @@ namespace NiflySharp
                 {
                     // Start a new set if the previous bones are different
                     // Compare bone palettes by content (SequenceEqual), not by List<> reference.
-                    // Matches C++ nifly NifFile.cpp:4458 `partitions[i].bones != partitions[i - 1].bones`
-                    // where `bones` is `std::vector<uint16_t>` whose `operator!=` is a content
-                    // comparison. The C# `List<ushort>` `!=` falls back to reference equality and
-                    // is almost always true, forcing PF_START_NET_BONESET on every partition.
                     if (skinPart.Partitions.Count > i &&
                         !skinPart.Partitions[i].Bones.SequenceEqual(skinPart.Partitions[i - 1].Bones))
                         flags |= BSPartFlag.PF_START_NET_BONESET;


### PR DESCRIPTION
`UpdatePartitionFlags` checks `Partitions[i].Bones != Partitions[i-1].Bones` to decide whether to emit a "start net boneset" flag. In C# `!=` on `List<>` is reference equality, so two partitions that happen to share contents but are distinct list instances will always be flagged as different — the flag becomes meaningless.

C++ reference: `nifly/NifFile.cpp:4458` — comparison uses `std::vector<uint16_t>::operator!=`, which is element-wise.

Fix: use `!SequenceEqual(...)` for the C# equivalent.

Maps to issue #15 item B6.
