### PR TITLE
OptimizeFor toLE: report against bsOptShape after ReplaceBlock

### DIFF
--- a/NiflySharp/NifFile.cs
+++ b/NiflySharp/NifFile.cs
@@ -2178,10 +2178,8 @@ namespace NiflySharp
                     }
 
                     bool withoutNormals = false;
+
                     // Capture report booleans locally and fire them against `bsOptShape`
-                    // AFTER the ReplaceBlock call below. Before this fix, the reports
-                    // referenced `shape` (the orphaned block) — matches what the toSSE
-                    // branch above does and the C++ pattern in NifFile.cpp:1773,1960.
                     bool didRemoveNormals = false;
                     bool didRemoveParallax = false;
 
@@ -2193,8 +2191,7 @@ namespace NiflySharp
                             // No normals and tangents with model space maps
                             if (bslsp.ModelSpace)
                             {
-                                // Report "normals removed" when there were normals to
-                                // remove. Matches C++ NifFile.cpp:1823 `if (!normals->empty())`.
+                                // Report "normals removed" when there were normals to remove.
                                 if (normals.Count > 0)
                                     didRemoveNormals = true;
 
@@ -2351,11 +2348,7 @@ namespace NiflySharp
                     ReplaceBlock(shape, bsOptShape);
                     UpdateSkinPartitions(bsOptShape);
 
-                    // Fire reports against the live block (bsOptShape) — `shape` has
-                    // been replaced and is now orphaned. Matches the toSSE branch above
-                    // and the C++ pattern where reports use `shapeName` (a string that
-                    // outlives the replace) at NifFile.cpp:1567-1762 before the
-                    // ReplaceBlock at NifFile.cpp:1773.
+                    // Fire reports against the live block (bsOptShape) — `shape` has been replaced and is now orphaned.
                     if (didRemoveNormals) result.ShapesNormalsRemoved.Add(bsOptShape);
                     if (didRemoveParallax) result.ShapesParallaxRemoved.Add(bsOptShape);
                     if (didRemoveVertexColors) result.ShapesVertexColorsRemoved.Add(bsOptShape);

--- a/NiflySharp/NifFile.cs
+++ b/NiflySharp/NifFile.cs
@@ -2178,6 +2178,12 @@ namespace NiflySharp
                     }
 
                     bool withoutNormals = false;
+                    // Capture report booleans locally and fire them against `bsOptShape`
+                    // AFTER the ReplaceBlock call below. Before this fix, the reports
+                    // referenced `shape` (the orphaned block) — matches what the toSSE
+                    // branch above does and the C++ pattern in NifFile.cpp:1773,1960.
+                    bool didRemoveNormals = false;
+                    bool didRemoveParallax = false;
 
                     var shader = GetShader(shape);
                     if (shader != null)
@@ -2187,8 +2193,10 @@ namespace NiflySharp
                             // No normals and tangents with model space maps
                             if (bslsp.ModelSpace)
                             {
-                                if (normals.Count == 0)
-                                    result.ShapesNormalsRemoved.Add(shape);
+                                // Report "normals removed" when there were normals to
+                                // remove. Matches C++ NifFile.cpp:1823 `if (!normals->empty())`.
+                                if (normals.Count > 0)
+                                    didRemoveNormals = true;
 
                                 withoutNormals = true;
                             }
@@ -2225,7 +2233,7 @@ namespace NiflySharp
                                     if (textureSet != null && textureSet.Textures.Count >= 4)
                                         textureSet.Textures[3].Content = string.Empty;
 
-                                    result.ShapesParallaxRemoved.Add(shape);
+                                    didRemoveParallax = true;
                                 }
                             }
                         }
@@ -2245,8 +2253,7 @@ namespace NiflySharp
                         }
                     }
 
-                    if (withoutVertexColors && vertexColors.Count > 0)
-                        result.ShapesVertexColorsRemoved.Add(shape);
+                    bool didRemoveVertexColors = (withoutVertexColors && vertexColors.Count > 0);
 
                     NiTriShape bsOptShape = null;
                     var bsOptShapeData = new NiTriShapeData();
@@ -2320,7 +2327,7 @@ namespace NiflySharp
                                 {
                                     bool triangulated = skinPart.ConvertStripsToTriangles();
                                     if (triangulated)
-                                        result.ShapesPartitionsTriangulated.Add(shape);
+                                        result.ShapesPartitionsTriangulated.Add(bsOptShape);
 
                                     var partitionsSpan = CollectionsMarshal.AsSpan(skinPart.Partitions);
 
@@ -2339,11 +2346,20 @@ namespace NiflySharp
                         bsOptShape.HasVertices = false;
 
                     // Check if tangents were added
-                    if (!shape.HasTangents && bsOptShape.HasTangents)
-                        result.ShapesTangentsAdded.Add(shape);
+                    bool didAddTangents = (!shape.HasTangents && bsOptShape.HasTangents);
 
                     ReplaceBlock(shape, bsOptShape);
                     UpdateSkinPartitions(bsOptShape);
+
+                    // Fire reports against the live block (bsOptShape) — `shape` has
+                    // been replaced and is now orphaned. Matches the toSSE branch above
+                    // and the C++ pattern where reports use `shapeName` (a string that
+                    // outlives the replace) at NifFile.cpp:1567-1762 before the
+                    // ReplaceBlock at NifFile.cpp:1773.
+                    if (didRemoveNormals) result.ShapesNormalsRemoved.Add(bsOptShape);
+                    if (didRemoveParallax) result.ShapesParallaxRemoved.Add(bsOptShape);
+                    if (didRemoveVertexColors) result.ShapesVertexColorsRemoved.Add(bsOptShape);
+                    if (didAddTangents) result.ShapesTangentsAdded.Add(bsOptShape);
                 }
 
                 RemoveUnreferencedBlocks();


### PR DESCRIPTION
The toLE branch of `OptimizeFor` adds `shape` to several `result.ShapesXxx` lists, then calls `ReplaceBlock(shape, bsOptShape)` which orphans the original. Callers that read the result lists end up with references to the now-detached shape.

Five sites affected: `ShapesVColorsRemoved`, `ShapesNormalsRemoved` (which also had its own condition inverted — `normals.Count == 0` should be `> 0`), `ShapesTangentsAdded`, `ShapesParallaxRemoved`, and the post-replace bookkeeping spot.

The toSSE branch already uses the "report after replace" ordering. This brings toLE in line.

C++ reference: `nifly/NifFile.cpp:1823` — `!normals.empty()` for the normals condition.

Maps to issue #15 items A3 and A4.
