### PR TITLE
NiGeometry: HasUVs/HasTangents setters honor value argument

### DIFF
--- a/NiflySharp/Blocks/NiGeometry.cs
+++ b/NiflySharp/Blocks/NiGeometry.cs
@@ -62,7 +62,7 @@ namespace NiflySharp.Blocks
             set
             {
                 if (GeometryData != null)
-                    GeometryData.HasUVs = true;
+                    GeometryData.HasUVs = value;
             }
         }
 
@@ -88,7 +88,7 @@ namespace NiflySharp.Blocks
             set
             {
                 if (GeometryData != null)
-                    GeometryData.HasTangents = true;
+                    GeometryData.HasTangents = value;
             }
         }
 


### PR DESCRIPTION
Both setters are hardcoded to `= true`, ignoring the caller's argument. `destShape.HasUVs = false` and `destShape.HasTangents = false` were silent no-ops.

This breaks `CloneShape`'s ModelSpace path, which does `destShape.HasTangents = false` (mirroring C++ `NifFile.cpp:1349` `bsOptShape->SetTangents(false)`) — the assignment never propagated to `GeometryData`.

C++ reference: `nifly/Geometry.cpp:288-292` and `:316-320` — `NiShape::SetUVs` / `NiShape::SetTangents` pass `enable` straight through to `geomData->SetUVs(enable)` / `geomData->SetTangents(enable)`.

`HasNormals` and `HasVertexColors` were already correct; only `HasUVs` and `HasTangents` had the typo.

Maps to issue #15 items E12 and E13.
