### PR TITLE
Don't set the Vertex attribute on BSDynamicTriShape in SetVertexPositions

### DIFF
--- a/NiflySharp/Blocks/BSTriShape.cs
+++ b/NiflySharp/Blocks/BSTriShape.cs
@@ -513,15 +513,25 @@ namespace NiflySharp.Blocks
         }
 
         /// <summary>
-        /// Sets mesh vertex positions and enables the vertices flag.
+        /// Sets mesh vertex positions. Enables the vertices flag, except on <see cref="BSDynamicTriShape"/>.
         /// </summary>
+        /// <remarks>
+        /// A <see cref="BSDynamicTriShape"/> must keep the <see cref="VertexAttribute.Vertex"/> flag off:
+        /// its positions live only in the dynamic vertex array, never in the static vertex data. That is
+        /// why its constructor clears the flag, and why <see cref="CalcDataSizes"/> assumes it is off.
+        /// Setting it would duplicate the positions into the static buffer, which no vanilla file does and
+        /// which breaks facial animation in-game (the head renders correctly but stops moving).
+        /// The static vertex data is still written below: <see cref="NifFile.FinalizeData"/> calls
+        /// <see cref="BSDynamicTriShape.CalcDynamicData"/>, which rebuilds the dynamic array from it.
+        /// </remarks>
         /// <param name="vertices">Positions for all vertices</param>
         public void SetVertexPositions(List<Vector3> vertices)
         {
             if (vertices.Count != _numVertices)
                 return;
 
-            HasVertices = true;
+            if (this is not BSDynamicTriShape)
+                HasVertices = true;
 
             rawVertexPositions = rawVertexPositions.Resize(_numVertices);
             var rawVerticesSpan = CollectionsMarshal.AsSpan(rawVertexPositions);

--- a/NiflySharp/Blocks/BSTriShape.cs
+++ b/NiflySharp/Blocks/BSTriShape.cs
@@ -126,7 +126,8 @@ namespace NiflySharp.Blocks
             {
                 if (value)
                 {
-                    _vertexDesc.VertexAttributes |= VertexAttribute.Vertex;
+                    if (this is not BSDynamicTriShape)
+                        _vertexDesc.VertexAttributes |= VertexAttribute.Vertex;
 
                     if (_vertexData_List_BSVDSSE != null)
                         _vertexData_List_BSVDSSE.Resize(_numVertices);
@@ -517,12 +518,7 @@ namespace NiflySharp.Blocks
         /// </summary>
         /// <remarks>
         /// A <see cref="BSDynamicTriShape"/> must keep the <see cref="VertexAttribute.Vertex"/> flag off:
-        /// its positions live only in the dynamic vertex array, never in the static vertex data. That is
-        /// why its constructor clears the flag, and why <see cref="CalcDataSizes"/> assumes it is off.
-        /// Setting it would duplicate the positions into the static buffer, which no vanilla file does and
-        /// which breaks facial animation in-game (the head renders correctly but stops moving).
-        /// The static vertex data is still written below: <see cref="NifFile.FinalizeData"/> calls
-        /// <see cref="BSDynamicTriShape.CalcDynamicData"/>, which rebuilds the dynamic array from it.
+        /// its positions live only in the dynamic vertex array, never in the static vertex data.
         /// </remarks>
         /// <param name="vertices">Positions for all vertices</param>
         public void SetVertexPositions(List<Vector3> vertices)
@@ -530,8 +526,7 @@ namespace NiflySharp.Blocks
             if (vertices.Count != _numVertices)
                 return;
 
-            if (this is not BSDynamicTriShape)
-                HasVertices = true;
+            HasVertices = true;
 
             rawVertexPositions = rawVertexPositions.Resize(_numVertices);
             var rawVerticesSpan = CollectionsMarshal.AsSpan(rawVertexPositions);


### PR DESCRIPTION
Hi Ousnius,

I ran into something while baking SSE FaceGen heads and I think it may be a discrepancy with nifly, though I'm not certain — I'd rather ask than assume.

`BSTriShape.SetVertexPositions()` does `HasVertices = true` unconditionally, including on `BSDynamicTriShape`. That turns on `VertexAttribute.Vertex` and duplicates the positions into the static vertex buffer (`VertexDataSize` 5 → 9 on a head), and `FinalizeData()` then stamps that desc into the `NiSkinPartition` and every `SkinPartition`.

What I observe: after that, the head renders correctly in-game but is frozen — no lip-sync, no expressions. Clearing the attribute again before save brings the animation back. I haven't traced the engine side, so I can only guess at the mechanism (my assumption is that with the flag set the position is read from the static buffer, and the dynamic array — which is what the facial animation writes into — stops being the source). But the correlation is solid on my end.

Repro: load a vanilla FaceGeom NIF, call `SetVertexPositions(shape.Vertices)` with the positions it already had, save. File grows 16 B/vertex, head stops animating. A plain load → save is fine — `PrepareData()` hydrates the static buffer from the dynamic array without touching the desc. Only `SetVertexPositions()` flips the bit.

**Comparing with nifly**, this looks like where the two diverge. As far as I can tell `SetVertexPositions` doesn't exist in nifly at all; the closest equivalent, `NifFile::SetVertsForShape`, writes the positions straight in and doesn't touch the flag:

```cpp
for (uint16_t i = 0; i < bsTriShape->GetNumVertices(); i++)
    bsTriShape->vertData[i].vert = verts[i];
```

`BSTriShape::SetVertices(bool)` does exist there (twin of the `HasVertices` setter), but as far as I can see the position-writing path never calls it. That's what makes me think the `HasVertices = true` in NiflySharp is unintended rather than deliberate — especially since the `BSDynamicTriShape` ctor clears the flag on purpose and `CalcDataSizes()` carries the comment `// "dynamic" meshes are false here`.

What this PR does:

```diff
 public void SetVertexPositions(List<Vector3> vertices)
 {
     if (vertices.Count != _numVertices)
         return;

-    HasVertices = true;
+    if (this is not BSDynamicTriShape)
+        HasVertices = true;
```

The rest of the method needs to stay, since `FinalizeData()` → `CalcDynamicData()` rebuilds the dynamic array from the static data.

I first tried deleting the line outright to mirror `SetVertsForShape`, but that broke things for me: nifly seems to fall back to `Create(...)` when the vertex count changes, which re-establishes the flags, and I don't think NiflySharp has an equivalent path — a consumer resizing via `SetVertexData()` (which sets `_numVertices` and resizes but leaves the desc alone) ends up relying on `SetVertexPositions()` to switch `Vertex` back on. The guard keeps that behaviour for static shapes.

All 34 tests still pass, and my heads now come out with a `VertexDesc` matching the CK's and animate again. But you know the library far better than I do — if I'm misreading the intent here, tell me.
