### PR TITLE
Expose TextureClampMode on BSLightingShaderProperty

### DIFF
--- a/NiflySharp/Blocks/BSLightingShaderProperty.cs
+++ b/NiflySharp/Blocks/BSLightingShaderProperty.cs
@@ -12,6 +12,8 @@ namespace NiflySharp.Blocks
         public bool HasTextureSet => !_textureSet?.IsEmpty() ?? false;
         public NiBlockRef<BSShaderTextureSet> TextureSetRef { get => _textureSet; set => _textureSet = value; }
 
+        public TexClampMode TextureClampMode { get => _textureClampMode; set => _textureClampMode = value; }
+
         public BSShaderType155 ShaderType_FO76_SF { get => _shaderType_BSST155; set => _shaderType_BSST155 = value; }
 
         /// <summary>


### PR DESCRIPTION
Hi ousnius,

Small addition: BSLightingShaderProperty didn't expose the Texture Clamp Mode
field. The generated partial already declares _textureClampMode as protected,
and the sibling classes BSShaderLightingProperty and BSEffectShaderProperty
both surface it with the same one-liner, so this looks like an omission rather
than an intentional gap.

    public TexClampMode TextureClampMode { get => _textureClampMode; set => _textureClampMode = value; }

It came up while comparing NIFs against CreationKit output: the clamp mode is
part of what distinguishes two otherwise identical BSShaderTextureSet blocks,
and without a public getter there's no way to read it.

No other changes, no behaviour change for existing consumers.

Thanks for the library!
