### PR TITLE
NiSkinPartition: derive MappedIndices from the version when reading

### DIFF
--- a/NiflySharp.Test/NifTests.cs
+++ b/NiflySharp.Test/NifTests.cs
@@ -1,4 +1,5 @@
 using NiflySharp.Blocks;
+using NiflySharp.Structs;
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -253,6 +254,113 @@ namespace NiflySharp.Test
             var fileInfoOutput = new FileInfo($"{OutputDirectory}/{TestName}.nif");
             var fileInfoExpected = new FileInfo($"{ExpectedDirectory}/{TestName}.nif");
             Assert.True(FilesAreEqual(fileInfoOutput, fileInfoExpected));
+        }
+
+        /// <summary>
+        /// Flattens triangles into their vertex indices, so a failed comparison
+        /// shows the differing index instead of an opaque list of triangles.
+        /// </summary>
+        private static IEnumerable<ushort> VertexIndices(IEnumerable<Triangle> triangles)
+        {
+            return triangles.SelectMany(tri => new[] { tri.V1, tri.V2, tri.V3 });
+        }
+
+        /// <summary>
+        /// Replaces the shape's single skin partition with two partitions, giving the first
+        /// one the triangles up to <paramref name="splitAt"/> and the second one the rest.
+        /// The shipped fixtures only have one partition with an identity vertex map, where
+        /// indices into the map and into the shape are the same.
+        /// </summary>
+        private static NiSkinPartition SplitSkinPartitionInTwo(NifFile nif, INiShape shape, int splitAt)
+        {
+            var skinInst = nif.GetBlock<NiSkinInstance>(shape.SkinInstanceRef);
+            Assert.NotNull(skinInst);
+
+            var skinPart = nif.GetBlock(skinInst.SkinPartition);
+            Assert.NotNull(skinPart);
+            Assert.Single(skinPart.Partitions);
+
+            var source = skinPart.Partitions[0];
+            var partTris = new List<Triangle>(source.TrianglesCopy);
+
+            var first = source;
+            first.TrianglesCopy = partTris.GetRange(0, splitAt);
+            first.NumTriangles = (ushort)first.TrianglesCopy.Count;
+
+            var second = source;
+            second.TrianglesCopy = partTris.GetRange(splitAt, partTris.Count - splitAt);
+            second.NumTriangles = (ushort)second.TrianglesCopy.Count;
+
+            skinPart.Partitions = [first, second];
+            skinPart.NumPartitions = 2;
+
+            // The partition index of each triangle is derived from the partitions' triangles
+            skinPart.GenerateTriPartsFromTrueTriangles(shape.Triangles);
+
+            if (skinInst is BSDismemberSkinInstance dismemberSkinInst)
+                dismemberSkinInst.Partitions.Add(dismemberSkinInst.Partitions[0]);
+
+            return skinPart;
+        }
+
+        [Fact(DisplayName = "Update skin partitions with unmapped triangle indices (SE)")]
+        public void UpdateSkinPartitions_UnmappedIndices_SE()
+        {
+            const string TestName = "UpdateSkinPartitions_UnmappedIndices_SE";
+
+            var nif = new NifFile();
+            Assert.Equal(0, nif.Load($"{AssetsDirectory}/V20.2.0.7/12/100/Skinned.nif"));
+
+            foreach (var shape in nif.GetShapes())
+            {
+                var skinPart = SplitSkinPartitionInTwo(nif, shape, shape.Triangles.Count / 2);
+                nif.UpdateSkinPartitions(shape);
+
+                // Both partitions must end up with a partial vertex map, or mapped and
+                // unmapped indices would be indistinguishable and the test wouldn't gate anything
+                Assert.All(skinPart.Partitions, part => Assert.True(part.VertexMap.Count < shape.VertexCount));
+
+                // SE indexes the shape's vertex list, not the partition's vertex map
+                Assert.All(skinPart.Partitions, part => Assert.Equal(VertexIndices(part.TrianglesCopy), VertexIndices(part.Triangles)));
+            }
+
+            Assert.Equal(0, nif.Save($"{OutputDirectory}/{TestName}.nif"));
+
+            // The saved indices are what other tools read, so check them after a round trip
+            var nifReloaded = new NifFile();
+            Assert.Equal(0, nifReloaded.Load($"{OutputDirectory}/{TestName}.nif"));
+
+            foreach (var shape in nifReloaded.GetShapes())
+            {
+                var skinInst = nifReloaded.GetBlock<NiSkinInstance>(shape.SkinInstanceRef);
+                Assert.NotNull(skinInst);
+
+                var skinPart = nifReloaded.GetBlock(skinInst.SkinPartition);
+                Assert.NotNull(skinPart);
+
+                Assert.Equal(2, skinPart.Partitions.Count);
+                Assert.All(skinPart.Partitions, part => Assert.True(part.VertexMap.Count < shape.VertexCount));
+                Assert.All(skinPart.Partitions, part => Assert.Equal(VertexIndices(part.TrianglesCopy), VertexIndices(part.Triangles)));
+            }
+        }
+
+        [Fact(DisplayName = "Update skin partitions with a partition without triangles (SE)")]
+        public void UpdateSkinPartitions_EmptyPartition_SE()
+        {
+            var nif = new NifFile();
+            Assert.Equal(0, nif.Load($"{AssetsDirectory}/V20.2.0.7/12/100/Skinned.nif"));
+
+            foreach (var shape in nif.GetShapes())
+            {
+                // The second partition gets no triangles at all
+                var skinPart = SplitSkinPartitionInTwo(nif, shape, shape.Triangles.Count);
+                nif.UpdateSkinPartitions(shape);
+
+                Assert.Equal(2, skinPart.Partitions.Count);
+                Assert.Equal(shape.Triangles.Count, skinPart.Partitions[0].Triangles.Count);
+                Assert.Empty(skinPart.Partitions[1].Triangles);
+                Assert.Equal(0, skinPart.Partitions[1].NumBones);
+            }
         }
 
         [Fact(DisplayName = "Load and save file with non-zero index root node (LE)")]

--- a/NiflySharp/Blocks/NiSkinPartition.cs
+++ b/NiflySharp/Blocks/NiSkinPartition.cs
@@ -48,8 +48,20 @@ namespace NiflySharp.Blocks
             return triangulated;
         }
 
+        partial void CopyFromExtra(NiSkinPartition other)
+        {
+            mappedIndices = other.mappedIndices;
+            triParts = other.triParts == null ? [] : new List<int>(other.triParts);
+        }
+
         public new void BeforeSync(NiStreamReversible stream)
         {
+            if (stream.CurrentMode == NiStreamReversible.Mode.Read)
+            {
+                if (stream.Version.UserVersion >= 12 && stream.Version.StreamVersion == 100)
+                    mappedIndices = false;
+            }
+
             if (stream.CurrentMode == NiStreamReversible.Mode.Write)
             {
                 if (stream.Version.StreamVersion == 100)

--- a/NiflySharp/Blocks/NiSkinPartition.cs
+++ b/NiflySharp/Blocks/NiSkinPartition.cs
@@ -51,15 +51,15 @@ namespace NiflySharp.Blocks
         partial void CopyFromExtra(NiSkinPartition other)
         {
             mappedIndices = other.mappedIndices;
-            triParts = other.triParts == null ? [] : new List<int>(other.triParts);
+            triParts = new List<int>(other.triParts);
         }
 
         public new void BeforeSync(NiStreamReversible stream)
         {
-            if (stream.CurrentMode == NiStreamReversible.Mode.Read)
+            if (stream.CurrentMode == NiStreamReversible.Mode.Read &&
+                stream.Version.UserVersion >= 12 && stream.Version.StreamVersion == 100)
             {
-                if (stream.Version.UserVersion >= 12 && stream.Version.StreamVersion == 100)
-                    mappedIndices = false;
+                mappedIndices = false;
             }
 
             if (stream.CurrentMode == NiStreamReversible.Mode.Write)

--- a/NiflySharp/NifFile.cs
+++ b/NiflySharp/NifFile.cs
@@ -2562,16 +2562,17 @@ namespace NiflySharp
 
             // Make a list of the bones used by each partition.
             // If any partition has too many bones, split it.
+            // Every partition needs its own set, including partitions without any
+            // triangles. They're never filled below and would otherwise stay null.
             var partBones = new List<HashSet<int>>(skinPart.Partitions.Count);
-            partBones.Resize(skinPart.Partitions.Count);
+            for (int partInd = 0; partInd < skinPart.Partitions.Count; ++partInd)
+                partBones.Add([]);
 
             for (int triIndex = 0; triIndex < tris.Count; ++triIndex)
             {
                 int partInd = skinPart.triParts[triIndex];
                 if (partInd < 0)
                     continue;
-
-                partBones[partInd] ??= [];
 
                 var tri = tris[triIndex];
 


### PR DESCRIPTION
Hi Ousnius,

`NiSkinPartition.mappedIndices` decides how the per-partition triangle indices are interpreted — into the partition's `VertexMap`, or straight into the shape's vertex list. It isn't a field in the file; nifly derives it from the version while reading:

```cpp
// nifly/src/Skin.cpp:111-113
if (stream.GetVersion().User() >= 12 && stream.GetVersion().Stream() == 100) {
    if (stream.GetMode() == NiStreamReversible::Mode::Reading)
        bMappedIndices = false;
```

That line isn't in NiflySharp, so the field keeps its `true` default. When `UpdateSkinPartitions` runs, `GenerateTrueTrianglesFromTriParts` empties `Triangles` and `PrepareVertexMapsAndTriangles` regenerates them through the vertex map — writing partition-local indices into an SSE file, where they should index the shape's vertices.

The library reads its own output back correctly, so the round-trip looks clean. Other consumers don't: NifSkope's `BSShape` concatenates each partition's `triangles` with no remap (`nifskope/src/gl/bsshape.cpp:141`) and draws the mesh as garbage.

Same slider set, built with BodySlide.exe and with NiflySharp:

| | part.Triangles max index | VertexMap size |
|---|---|---|
| BodySlide | 1498 / 1797 | 164 / 1681 |
| NiflySharp | 163 / 1680 | 164 / 1681 |

`CopyFromExtra` also wasn't implemented on this block, so cloning a partition dropped `mappedIndices` and `triParts`.

Fix: port the read-side assignment into `BeforeSync`, and implement `CopyFromExtra`.

I checked the other places nifly assigns the flag, to make sure the read side is the only gap: the two in `OptimizeFor` are already present here (`NifFile.cs:2231` and `2459`), and `SetDefaultPartition` / `CreateSkinning` aren't ported to NiflySharp. Nothing constructs a `NiSkinPartition` from scratch either, so read + clone + those two cover every path.

**One caveat on test coverage.** The shipped fixtures can't exhibit this. `Assets/V20.2.0.7/12/100/Skinned.nif` has a single partition with an identity vertex map (max triangle index 135, map size 136), so both branches produce the same triangles and the saved file is byte-identical with and without the fix. To get a real gate I forced a non-identity map on that fixture's partition (keeping only triangles whose vertices are all >= 68), which separates the branches cleanly:

```
mappedIndices=false -> Triangles max index = 135   VertexMap size = 68   (indexes the shape - correct for SSE)
mappedIndices=true  -> Triangles max index =  67   VertexMap size = 68   (indexes the vertex map)
```

Happy to add that as a unit test, or a multi-partition SSE fixture if you'd rather have one.

FO4 is untouched (stream 130 skins use `BSSkin::Instance` and have no `NiSkinPartition` — confirmed, 0 blocks in the FO4 fixtures), and Skyrim LE keeps `true`, same as nifly.

Thanks!
