### PR TITLE
BSShaderProperty: carry Type through the copy constructor

### DIFF
--- a/NiflySharp/Blocks/BSShaderProperty.cs
+++ b/NiflySharp/Blocks/BSShaderProperty.cs
@@ -8,6 +8,12 @@ namespace NiflySharp.Blocks
     {
         public ShaderGameType Type { get; set; }
 
+        // Type is not a file field, so the generated copy constructor doesn't cover it
+        partial void CopyFromExtra(BSShaderProperty other)
+        {
+            Type = other.Type;
+        }
+
         /// <summary>
         /// Assigns the shader game type for legacy (FO3/NV) shader blocks.
         /// Modern shader blocks (BSLightingShaderProperty etc.) hide this with


### PR DESCRIPTION
Hi Ousnius,

nifly keeps one raw `uint32_t shaderFlags1` and tests the bit directly:

```cpp
// nifly/src/Shaders.cpp:268-270
bool BSShaderProperty::IsModelSpace() const {
    return (shaderFlags1 & (1 << 12)) != 0;
}
```

NiflySharp splits that into `_shaderFlags1_SSPF1` and `_shaderFlags1_F4SPF1`, so it needs `Type` to know which one to read. `Type` is assigned only in `BeforeSync` and isn't a nif.xml field, so the generated copy constructor doesn't carry it. A cloned shader starts at `ShaderGameType.None`, every `*FlagValue` helper returns 0, `HasFlagSF1/2` return false, and `SetFlagSF1/2` drop the write.

Measured on a cloned `BSLightingShaderProperty`, before the fix:

```
SSE  srcType=SK   cloneType=None  srcModelSpace=True  cloneModelSpace=False
FO4  srcType=FO4  cloneType=None  srcModelSpace=True  cloneModelSpace=False
clone.Emissive after setting it to true = False
```

Where it shows: `CloneShape` reads `destShader.ModelSpace` on the fresh clone, so for SK/SSE it never strips normals and tangents from a model-space shape. nifly does (`nifly/src/NifFile.cpp:1380-1389`).

Fix: implement `CopyFromExtra` on `BSShaderProperty`. The derived shader classes chain through `: base(other)`, so one implementation covers them. `Type` is the only non-file property on any of the shader classes, so nothing else is missing from the copy.

**This changes written bytes in two places**, both of them the point of the fix:

- flag writes on a cloned shader stop being dropped, so clone-then-mutate now matches fresh-then-mutate;
- `CloneShape` on a model-space SK/SSE shape now strips normals and tangents (`clone.HasNormals` goes True -> False), matching nifly.

No shipped fixture exercises either path — every file under `Assets/`, three consecutive saves each, digests unchanged.

Thanks!
