### PR TITLE
BSTriShape: restore the counters BeforeSync zeroes for SSE skinned shapes

### DIFF
--- a/NiflySharp.Test/NifTests.cs
+++ b/NiflySharp.Test/NifTests.cs
@@ -1,9 +1,11 @@
 using NiflySharp.Blocks;
+using NiflySharp.Structs;
 using System;
 using System.Diagnostics;
 using System.IO;
 using System.Collections.Generic;
 using System.Linq;
+using System.Numerics;
 using Xunit;
 
 namespace NiflySharp.Test
@@ -844,6 +846,165 @@ namespace NiflySharp.Test
             using var input = new MemoryStream(output.ToArray(), false);
             Assert.Equal(0, loaded.Load(input));
             Assert.Equal(rootIds, loaded.Header.RootBlockIds);
+        }
+
+        [Fact(DisplayName = "Save keeps geometry counters on skinned shapes (SE)")]
+        public void SaveKeepsGeometryCounters_SkinnedSSE()
+        {
+            var nif = new NifFile();
+            Assert.Equal(0, nif.Load($"{AssetsDirectory}/V20.2.0.7/12/100/Skinned.nif"));
+
+            var shapes = nif.GetShapes().OfType<BSTriShape>().ToList();
+            Assert.NotEmpty(shapes);
+            Assert.All(shapes, shape => Assert.True(shape.IsSkinned));
+
+            using var output = new MemoryStream();
+            Assert.Equal(0, nif.Save(output));
+
+            // A skinned shape writes zeros for its counts because the geometry lives in the
+            // NiSkinPartition, but it has to keep them. Data size is recalculated from those
+            // counts on every save, so a zero here means they were lost.
+            Assert.All(shapes, shape => Assert.True(shape.DataSize > 0));
+        }
+
+        [Fact(DisplayName = "Edit after save is kept on skinned shapes (SE)")]
+        public void EditAfterSaveIsKept_SkinnedSSE()
+        {
+            var nif = new NifFile();
+            Assert.Equal(0, nif.Load($"{AssetsDirectory}/V20.2.0.7/12/100/Skinned.nif"));
+
+            var shape = nif.GetShapes().OfType<BSTriShape>().First();
+            var original = shape.VertexPositions.ToList();
+            Assert.NotEmpty(original);
+
+            using var firstSave = new MemoryStream();
+            Assert.Equal(0, nif.Save(firstSave));
+
+            shape.SetVertexPositions([.. original.Select(v => new Vector3(v.X + 10.0f, v.Y, v.Z))]);
+
+            using var secondSave = new MemoryStream();
+            Assert.Equal(0, nif.Save(secondSave));
+
+            var reloaded = new NifFile();
+            using var input = new MemoryStream(secondSave.ToArray(), false);
+            Assert.Equal(0, reloaded.Load(input));
+
+            var reloadedPositions = reloaded.GetShapes().OfType<BSTriShape>().First().VertexPositions;
+            Assert.Equal(original.Count, reloadedPositions.Count);
+            Assert.All(reloadedPositions.Zip(original), pair => Assert.Equal(pair.Second.X + 10.0f, pair.First.X, 3));
+        }
+
+        [Fact(DisplayName = "Save keeps particle data on skinned shapes (SE)")]
+        public void SaveKeepsParticleData_SkinnedSSE()
+        {
+            var nif = new NifFile();
+            Assert.Equal(0, nif.Load($"{AssetsDirectory}/V20.2.0.7/12/100/Skinned.nif"));
+
+            var shape = nif.GetShapes().OfType<BSTriShape>().First();
+            Assert.True(shape.IsSkinned);
+
+            AddParticleData(shape);
+            int vertexCount = shape.VertexCount;
+            int triangleCount = shape.TriangleCount;
+
+            using var output = new MemoryStream();
+            Assert.Equal(0, nif.Save(output));
+
+            // The save cannot write particle arrays for a skinned shape, but it must not
+            // consume them either.
+            Assert.Equal(vertexCount, shape.ParticleVertices.Count);
+            Assert.Equal(vertexCount, shape.ParticleNormals.Count);
+            Assert.Equal(triangleCount, shape.ParticleTriangles.Count);
+            Assert.Equal((uint)((vertexCount * 6) + (triangleCount * 3)), shape.ParticleDataSize);
+
+            // The vertex and triangle counts a reader uses to find the particle arrays are
+            // written as zero for a skinned shape, so the size on disk has to be zero too.
+            var reloaded = new NifFile();
+            using var input = new MemoryStream(output.ToArray(), false);
+            Assert.Equal(0, reloaded.Load(input));
+
+            var reloadedShape = reloaded.GetShapes().OfType<BSTriShape>().First();
+            Assert.Equal(0u, reloadedShape.ParticleDataSize);
+            Assert.Empty(reloadedShape.ParticleVertices ?? []);
+        }
+
+        [Fact(DisplayName = "Save keeps particle data on skinned dynamic shapes (SE)")]
+        public void SaveKeepsParticleData_SkinnedDynamicSSE()
+        {
+            var nif = new NifFile();
+            Assert.Equal(0, nif.Load($"{AssetsDirectory}/V20.2.0.7/12/100/SkinnedDynamic.nif"));
+
+            var shape = nif.GetShapes().OfType<BSDynamicTriShape>().First();
+            Assert.True(shape.IsSkinned);
+
+            AddParticleData(shape);
+            int vertexCount = shape.VertexCount;
+            int triangleCount = shape.TriangleCount;
+
+            using var output = new MemoryStream();
+            Assert.Equal(0, nif.Save(output));
+
+            Assert.Equal(vertexCount, shape.ParticleVertices.Count);
+            Assert.Equal(vertexCount, shape.ParticleNormals.Count);
+            Assert.Equal(triangleCount, shape.ParticleTriangles.Count);
+
+            // A dynamic shape writes its real vertex count, so the particle vertices and
+            // normals still round-trip. Its triangle count is written as zero, so the
+            // particle triangles cannot be, and the size has to leave them out.
+            var reloaded = new NifFile();
+            using var input = new MemoryStream(output.ToArray(), false);
+            Assert.Equal(0, reloaded.Load(input));
+
+            var reloadedShape = reloaded.GetShapes().OfType<BSDynamicTriShape>().First();
+            Assert.Equal((uint)(vertexCount * 6), reloadedShape.ParticleDataSize);
+            Assert.Equal(vertexCount, reloadedShape.ParticleVertices.Count);
+            Assert.Equal(vertexCount, reloadedShape.ParticleNormals.Count);
+            Assert.Empty(reloadedShape.ParticleTriangles ?? []);
+        }
+
+        [Fact(DisplayName = "Save round-trips particle data on unskinned shapes (SE)")]
+        public void SaveRoundTripsParticleData_UnskinnedSSE()
+        {
+            var nif = new NifFile();
+            Assert.Equal(0, nif.Load($"{AssetsDirectory}/V20.2.0.7/12/100/Static.nif"));
+
+            var shape = nif.GetShapes().OfType<BSTriShape>().First();
+            Assert.False(shape.IsSkinned);
+
+            AddParticleData(shape);
+            int vertexCount = shape.VertexCount;
+            int triangleCount = shape.TriangleCount;
+
+            using var output = new MemoryStream();
+            Assert.Equal(0, nif.Save(output));
+
+            var reloaded = new NifFile();
+            using var input = new MemoryStream(output.ToArray(), false);
+            Assert.Equal(0, reloaded.Load(input));
+
+            // An unskinned shape writes its real counts, so the particle arrays survive
+            // the round-trip at the size nif.xml calculates for them.
+            var reloadedShape = reloaded.GetShapes().OfType<BSTriShape>().First();
+            Assert.Equal((uint)((vertexCount * 6) + (triangleCount * 3)), reloadedShape.ParticleDataSize);
+            Assert.Equal(vertexCount, reloadedShape.ParticleVertices.Count);
+            Assert.Equal(vertexCount, reloadedShape.ParticleNormals.Count);
+            Assert.Equal(triangleCount, reloadedShape.ParticleTriangles.Count);
+            Assert.Equal(shape.ParticleTriangles, reloadedShape.ParticleTriangles);
+        }
+
+        /// <summary>
+        /// Fills in particle data the way OptimizeFor does for a shape carrying NiOptimizeKeep.
+        /// </summary>
+        private static void AddParticleData(BSTriShape shape)
+        {
+            Assert.True(shape.VertexCount > 0);
+            Assert.True(shape.TriangleCount > 0);
+
+            shape.ParticleVertices = [.. shape.VertexPositions.Select(v =>
+                new HalfVector3() { X = (Half)v.X, Y = (Half)v.Y, Z = (Half)v.Z })];
+            shape.ParticleNormals = [.. shape.ParticleVertices];
+            shape.ParticleTriangles = [.. shape.Triangles];
+            shape.ParticleDataSize = (uint)((shape.VertexCount * 6) + (shape.TriangleCount * 3));
         }
     }
 }

--- a/NiflySharp/Blocks/BSTriShape.cs
+++ b/NiflySharp/Blocks/BSTriShape.cs
@@ -46,6 +46,14 @@ namespace NiflySharp.Blocks
         internal List<Color4> rawVertexColors;      // temporary copy filled by UpdateRawColors function
         internal List<float> rawEyeData;            // temporary copy filled by UpdateRawEyeData function
 
+        // Kept by BeforeSync, put back by AfterSync
+        private bool _countersStashed;
+        private ushort _stashNumVertices;
+        private uint _stashNumTriangles_ui;
+        private ushort _stashNumTriangles_us;
+        private uint _stashDataSize;
+        private uint _stashParticleDataSize;
+
         public BSTriShape()
         {
             _boundMinMax = new float[6];
@@ -71,6 +79,15 @@ namespace NiflySharp.Blocks
 
                 if (stream.Version.IsSSE() && IsSkinned)
                 {
+                    RestoreStashedCounters();
+
+                    _stashNumVertices = _numVertices;
+                    _stashNumTriangles_ui = _numTriangles_ui;
+                    _stashNumTriangles_us = _numTriangles_us;
+                    _stashDataSize = _dataSize;
+                    _stashParticleDataSize = _particleDataSize;
+                    _countersStashed = true;
+
                     // Triangle and vertex data is in partition instead
                     _numVertices = 0;
                     _numTriangles_ui = 0;
@@ -93,6 +110,28 @@ namespace NiflySharp.Blocks
                     }
                 }
             }
+        }
+
+        public new void AfterSync(NiStreamReversible stream)
+        {
+            RestoreStashedCounters();
+        }
+
+        private void RestoreStashedCounters()
+        {
+            if (!_countersStashed)
+                return;
+
+            _countersStashed = false;
+
+            // BSDynamicTriShape keeps the count BeforeSync assigned from its dynamic vertices
+            if (this is not BSDynamicTriShape)
+                _numVertices = _stashNumVertices;
+
+            _numTriangles_ui = _stashNumTriangles_ui;
+            _numTriangles_us = _stashNumTriangles_us;
+            _dataSize = _stashDataSize;
+            _particleDataSize = _stashParticleDataSize;
         }
 
         public void UpdateBounds()

--- a/NiflySharp/Blocks/BSTriShape.cs
+++ b/NiflySharp/Blocks/BSTriShape.cs
@@ -53,6 +53,7 @@ namespace NiflySharp.Blocks
         private ushort _stashNumTriangles_us;
         private uint _stashDataSize;
         private uint _stashParticleDataSize;
+        private List<Triangle> _stashParticleTriangles;
 
         public BSTriShape()
         {
@@ -86,6 +87,10 @@ namespace NiflySharp.Blocks
                     _stashNumTriangles_us = _numTriangles_us;
                     _stashDataSize = _dataSize;
                     _stashParticleDataSize = _particleDataSize;
+
+                    // Particle triangles are sized by the triangle count, which is written
+                    // as zero below, so the write truncates them away. Keep a copy.
+                    _stashParticleTriangles = _particleTriangles?.Count > 0 ? [.. _particleTriangles] : null;
                     _countersStashed = true;
 
                     // Triangle and vertex data is in partition instead
@@ -101,12 +106,19 @@ namespace NiflySharp.Blocks
 
                 if (stream.Version.IsSSE())
                 {
-                    if (_particleDataSize > 0)
-                        _particleDataSize = (uint)((_numVertices * 6) + (numTris * 3));
-
                     if (this is BSDynamicTriShape bsdts)
                     {
                         _numVertices = (ushort)(bsdts.Vertices?.Count ?? 0);
+                    }
+
+                    // A reader sizes the particle arrays from the vertex and triangle counts
+                    // as written, not from the ones this shape holds, so the size has to be
+                    // derived from those too. On a skinned shape both are zeroed above (bar
+                    // the vertex count on BSDynamicTriShape), leaving nothing to point at.
+                    if (_particleDataSize > 0)
+                    {
+                        uint writtenTris = _numTriangles_ui > 0 ? _numTriangles_ui : _numTriangles_us;
+                        _particleDataSize = (uint)((_numVertices * 6) + (writtenTris * 3));
                     }
                 }
             }
@@ -117,6 +129,12 @@ namespace NiflySharp.Blocks
             RestoreStashedCounters();
         }
 
+        /// <summary>
+        /// Puts back the counters <see cref="BeforeSync"/> zeroes for skinned SSE shapes.
+        /// Without this the shape is left reporting no vertices and no triangles after a
+        /// save, which silently disables every Set* method and makes the next save
+        /// recompute a zero data size from the zeroed counts.
+        /// </summary>
         private void RestoreStashedCounters()
         {
             if (!_countersStashed)
@@ -132,6 +150,12 @@ namespace NiflySharp.Blocks
             _numTriangles_us = _stashNumTriangles_us;
             _dataSize = _stashDataSize;
             _particleDataSize = _stashParticleDataSize;
+
+            if (_stashParticleTriangles != null)
+            {
+                _particleTriangles = _stashParticleTriangles;
+                _stashParticleTriangles = null;
+            }
         }
 
         public void UpdateBounds()


### PR DESCRIPTION
Hi Ousnius,

An SSE skinned shape writes zeros for its vertex and triangle counts, since the data lives in the `NiSkinPartition`. nifly writes those zeros from locals and leaves the members alone:

```cpp
// nifly/src/Geometry.cpp:484-493
uint16_t numUShort = 0;
uint32_t numUInt = 0;
stream.Sync(numUShort);
...
stream.Sync(numUInt);
```

The generated `Sync` emits the fields by reference, so `BeforeSync` has to zero `_numVertices`, `_numTriangles_ui/_us` and `_dataSize` to produce the same bytes — and nothing puts them back. After a save the shape is left with `_numVertices == 0`, which silently disables `SetVertexPositions`, `SetNormals`, `SetTangents`, `SetBitangents`, `SetUVs`, `SetVertexColors` and `SetEyeData` (all early-return on the count), and makes `HasVertices = true` resize the vertex data to zero.

On `Assets/V20.2.0.7/12/100/Skinned.nif`, load -> save -> `SetVertexPositions(shifted)` -> save produces a file byte-identical to the unedited save. The edit is gone.

```
before:  numVertices after save1 = 0    save1 == save2    readback delta X = 0
after:   numVertices after save1 = 136  save1 != save2    readback delta X = 10
```

Fix: stash the counters before zeroing and restore them in a new `AfterSync`.

Two things worth flagging in the restore:

- **`BSDynamicTriShape` deliberately keeps the `_numVertices` that `BeforeSync` assigns from its dynamic vertices.** Its `Dynamic Data Size` is `calc="Num Vertices #MUL# 16"` and it is written *after* `BSTriShape.AfterSync` has run (the base `Sync` completes first), so restoring the stashed count there would corrupt the dynamic block.
- **The restored `_dataSize` is the value `FinalizeData` computed, not the zero read from the file.** `NifFile.Save` calls `CalcDataSizes` before the write pass, so the stash is taken after it. That matches nifly, which also calls `CalcDataSizes` in `FinalizeData` and never zeroes the member.

Byte-neutral — every fixture under `Assets/`, three consecutive saves each, digests identical with and without the change. Note this corpus contains no `BSSubIndexTriShape`, the one subclass where restoring mid-`Sync` could in principle matter; I checked nif.xml instead — in SSE it writes only `Num Segments` and `Segment` (`#BS_SSE#`), and its `Data Size #GT# 0`-gated fields are `#BS_GTE_130#`, where `BSTriShape` never zeroes anything.

Thanks!
