### PR TITLE
NiSkinData: don't destroy bone counts and weights when saving

### DIFF
--- a/NiflySharp.Test/NifTests.cs
+++ b/NiflySharp.Test/NifTests.cs
@@ -1,4 +1,5 @@
 using NiflySharp.Blocks;
+using NiflySharp.Structs;
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -281,6 +282,50 @@ namespace NiflySharp.Test
             var fileInfoOutput = new FileInfo($"{OutputDirectory}/{TestName}.nif");
             var fileInfoExpected = new FileInfo($"{ExpectedDirectory}/{TestName}.nif");
             Assert.True(FilesAreEqual(fileInfoOutput, fileInfoExpected));
+        }
+
+        [Fact(DisplayName = "Keep NiSkinData bone weights in memory when saving without weights (SE)")]
+        public void SaveKeepsNoNiSkinDataWeights_SE()
+        {
+            var nif = new NifFile();
+            Assert.Equal(0, nif.Load($"{AssetsDirectory}/V20.2.0.7/12/100/NoNiSkinDataWeights.nif"));
+
+            var skinData = nif.Blocks.OfType<NiSkinData>().FirstOrDefault();
+            Assert.NotNull(skinData);
+            Assert.False(skinData.HasVertexWeights.GetValueOrDefault());
+            Assert.NotEmpty(skinData.BoneList);
+
+            // Give every bone weights the file can't hold, they have to survive the save
+            for (int i = 0; i < skinData.BoneList.Count; i++)
+            {
+                var bone = skinData.BoneList[i];
+                bone.VertexWeights = [
+                    new BoneVertData { Index = 0, Weight = 1.0f },
+                    new BoneVertData { Index = 1, Weight = 0.5f },
+                    new BoneVertData { Index = 2, Weight = 0.25f }];
+                bone.NumVertices = (ushort)bone.VertexWeights.Count;
+                skinData.BoneList[i] = bone;
+            }
+
+            byte[] expected = File.ReadAllBytes($"{ExpectedDirectory}/LoadAndSave_NoNiSkinDataWeights_SE.nif");
+
+            // Twice, because a save must not depend on the state a previous one left behind
+            for (int save = 0; save < 2; save++)
+            {
+                using var output = new MemoryStream();
+                Assert.Equal(0, nif.Save(output));
+
+                // The flag is false, so the file still gets zero counts and no weights at all
+                Assert.True(expected.AsSpan().SequenceEqual(output.ToArray()));
+
+                Assert.False(skinData.HasVertexWeights.GetValueOrDefault());
+                Assert.All(skinData.BoneList, bone =>
+                {
+                    Assert.Equal(3, bone.NumVertices);
+                    Assert.Equal(3, bone.VertexWeights.Count);
+                    Assert.Equal(0.5f, bone.VertexWeights[1].Weight);
+                });
+            }
         }
 
         [Fact(DisplayName = "Load and save animated file (LE)")]
@@ -751,6 +796,42 @@ namespace NiflySharp.Test
 
                 Assert.True(original.AsSpan().SequenceEqual(output.ToArray()), fileName);
             }
+        }
+
+        [Fact(DisplayName = "Write NiSkinData bone weights regardless of the flag (MW)")]
+        public void WriteNoNiSkinDataWeights_MW()
+        {
+            // The flag is not part of the file below version 4.2.1.0, where weights are always present
+            byte[] original = File.ReadAllBytes($"{MorrowindDirectory}/Skinned.nif");
+
+            var nif = new NifFile();
+            using var input = new MemoryStream(original, false);
+            Assert.Equal(0, nif.Load(input));
+
+            var skinData = nif.Blocks.OfType<NiSkinData>().FirstOrDefault();
+            Assert.NotNull(skinData);
+            Assert.NotEmpty(skinData.BoneList);
+            Assert.All(skinData.BoneList, bone => Assert.NotEmpty(bone.VertexWeights));
+
+            skinData.HasVertexWeights = false;
+
+            var saveOptions = new NifFileSaveOptions
+            {
+                RemoveUnreferencedBlocks = false,
+                SortBlocks = false,
+                UpdateBounds = false
+            };
+
+            using var output = new MemoryStream();
+            Assert.Equal(0, nif.Save(output, saveOptions));
+
+            // Clearing the flag must not drop the counts or the weights, from the file or from memory
+            Assert.True(original.AsSpan().SequenceEqual(output.ToArray()));
+            Assert.All(skinData.BoneList, bone =>
+            {
+                Assert.NotEqual(0, bone.NumVertices);
+                Assert.Equal(bone.NumVertices, bone.VertexWeights.Count);
+            });
         }
 
         [Fact(DisplayName = "Read blocks of static file (MW)")]

--- a/NiflySharp/Blocks/NiSkinData.cs
+++ b/NiflySharp/Blocks/NiSkinData.cs
@@ -1,15 +1,59 @@
 ﻿using NiflySharp.Extensions;
 using NiflySharp.Stream;
+using NiflySharp.Structs;
 using System.Runtime.InteropServices;
 
 namespace NiflySharp.Blocks
 {
     public partial class NiSkinData
     {
+        // Kept by BeforeSync, put back by AfterSync
+        private BoneData[] _bonesBeforeWrite;
+
         public new void BeforeSync(NiStreamReversible stream)
+        {
+            RestoreStashedBones();
+
+            // The flag is not in the file below that version, where weights are always present
+            if (stream.Version.FileVersion < NiFileVersion.V4_2_1_0)
+                _hasVertexWeights = true;
+
+            if (_hasVertexWeights == null)
+                _hasVertexWeights = true;
+
+            var boneListSpan = CollectionsMarshal.AsSpan(_boneList);
+
+            if (_hasVertexWeights.GetValueOrDefault())
+            {
+                foreach (ref var bone in boneListSpan)
+                    bone.VertexWeights = bone.VertexWeights.Resize(bone.NumVertices);
+
+                return;
+            }
+
+            if (stream.CurrentMode != NiStreamReversible.Mode.Write)
+                return;
+
+            // Zeros go to the file, the counts and weights come back in AfterSync
+            _bonesBeforeWrite = boneListSpan.ToArray();
+
+            foreach (ref var bone in boneListSpan)
+            {
+                bone.NumVertices = 0;
+                bone.VertexWeights = [];
+            }
+        }
+
+        public new void AfterSync(NiStreamReversible stream)
         {
             if (_hasVertexWeights == null)
                 _hasVertexWeights = true;
+
+            if (stream.CurrentMode == NiStreamReversible.Mode.Write)
+            {
+                RestoreStashedBones();
+                return;
+            }
 
             var boneListSpan = CollectionsMarshal.AsSpan(_boneList);
 
@@ -22,20 +66,17 @@ namespace NiflySharp.Blocks
             }
         }
 
-        public new void AfterSync(NiStreamReversible stream)
+        private void RestoreStashedBones()
         {
-            if (_hasVertexWeights == null)
-                _hasVertexWeights = true;
+            if (_bonesBeforeWrite == null)
+                return;
 
             var boneListSpan = CollectionsMarshal.AsSpan(_boneList);
 
-            foreach (ref var bone in boneListSpan)
-            {
-                if (!_hasVertexWeights.GetValueOrDefault())
-                    bone.NumVertices = 0;
+            for (int i = 0; i < boneListSpan.Length && i < _bonesBeforeWrite.Length; i++)
+                boneListSpan[i] = _bonesBeforeWrite[i];
 
-                bone.VertexWeights = bone.VertexWeights.Resize(bone.NumVertices);
-            }
+            _bonesBeforeWrite = null;
         }
     }
 }


### PR DESCRIPTION
Hi Ousnius,

`BeforeSync` and `AfterSync` both run the same mutation, in both directions:

```csharp
if (!_hasVertexWeights.GetValueOrDefault()) bone.NumVertices = 0;
bone.VertexWeights = bone.VertexWeights.Resize(bone.NumVertices);
```

nifly assigns `boneData.numVertices` only when reading, and resizes `vertexWeights` strictly inside the `hasVertWeights` branch:

```cpp
// nifly/src/Skin.cpp:49-53
if (stream.GetMode() == NiStreamReversible::Mode::Reading)
    boneData.numVertices = numVerts;

if (hasVertWeights) {
    boneData.vertexWeights.resize(numVerts);
```

So saving a `NiSkinData` whose flag is false destroys both the counts and the weight arrays in memory. On `Assets/V20.2.0.7/12/100/NoNiSkinDataWeights.nif` with weights injected: `n=3,3  w=3,3` before the save, `n=0,0  w=0,0` after it.

Fix: stash the bone data before zeroing the counts, so the writer still emits zeros, and put it back in `AfterSync`. The weight arrays need covering too, not just the counts: the generated `BoneData.Sync` resizes them at or below 4.2.1.0 regardless of the flag, and `SyncListContentStreamable` passes the struct by ref, so a zeroed count truncates the caller's list for real. `BeforeSync` hands the writer a throwaway list and the stash restores the original. The read path is unchanged.

It also picks up nifly's version rule, which NiflySharp didn't have:

```cpp
// nifly/src/Skin.cpp:24-27
if (stream.GetVersion().File() >= NiFileVersion::V4_2_1_0)
    stream.Sync(hasVertWeights);
else
    hasVertWeights = 1; // Vertex weights are always present before that version
```

Note the boundary is strict: at exactly 4.2.1.0 the flag *is* a file field and is honored, so only files below that version force it on. That changes bytes below 4.2.1.0, where the generated `BoneData.Sync` writes the weights regardless of the flag: `Assets/V4.0.0.2/Skinned.nif` with the flag false goes from 2134 to 2326 bytes, exactly the 32 weights x 6 that were being dropped. At 4.2.1.0 itself, a false flag still writes 2084 bytes as before — but the weights now survive in memory instead of being wiped.

No shipped fixture has the flag clear, so the corpus is byte-identical (every file under `Assets/`, three consecutive saves each).

Thanks!
