### PR TITLE
NiVersion.IsFO4: use the full 130-139 stream range

### DIFF
--- a/NiflySharp/BaseTypes/NiVersion.cs
+++ b/NiflySharp/BaseTypes/NiVersion.cs
@@ -171,7 +171,7 @@ namespace NiflySharp
 
         public bool IsFO4()
         {
-            return FileVersion == NiFileVersion.V20_2_0_7 && StreamVersion == 130;
+            return FileVersion == NiFileVersion.V20_2_0_7 && StreamVersion >= 130 && StreamVersion <= 139;
         }
 
         public bool IsFO76()


### PR DESCRIPTION
Hi Ousnius,

`IsFO4()` returns `StreamVersion == 130`, while nifly uses the range:

```cpp
// nifly/include/BasicTypes.hpp:159
bool IsFO4() const { return file == V20_2_0_7 && stream >= 130 && stream <= 139; }
```

`Assets/` already ships FO4 fixtures at stream 132 and 139 that the predicate reports as not-FO4.

Fix: one line, matching nifly. `IsFO4` has no call sites inside the library, so written bytes are unchanged — this only affects consumers classifying a file.

Thanks!
